### PR TITLE
Generate interface types from type definitions file

### DIFF
--- a/com-api/examples/com-api-gen/com-api-gen-iceoryx/Cargo.lock
+++ b/com-api/examples/com-api-gen/com-api-gen-iceoryx/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "abi-types-codegen"
 version = "0.1.0"
-source = "git+ssh://git@github.com/qorix-group/abi_tools_internal.git?rev=1196d20246a38718e469b42953714e5eddb15d56#1196d20246a38718e469b42953714e5eddb15d56"
+source = "git+ssh://git@github.com/qorix-group/abi_tools_internal.git?rev=1466ef338a666fa5b49a08cbabb48143c6a5efef#1466ef338a666fa5b49a08cbabb48143c6a5efef"
 dependencies = [
  "abi-types-parser",
  "anyhow",
@@ -15,7 +15,7 @@ dependencies = [
 [[package]]
 name = "abi-types-parser"
 version = "0.1.0"
-source = "git+ssh://git@github.com/qorix-group/abi_tools_internal.git?rev=1196d20246a38718e469b42953714e5eddb15d56#1196d20246a38718e469b42953714e5eddb15d56"
+source = "git+ssh://git@github.com/qorix-group/abi_tools_internal.git?rev=1466ef338a666fa5b49a08cbabb48143c6a5efef#1466ef338a666fa5b49a08cbabb48143c6a5efef"
 dependencies = [
  "anyhow",
  "ariadne",

--- a/com-api/examples/com-api-gen/com-api-gen-iceoryx/Cargo.lock
+++ b/com-api/examples/com-api-gen/com-api-gen-iceoryx/Cargo.lock
@@ -3,6 +3,29 @@
 version = 4
 
 [[package]]
+name = "abi-types-codegen"
+version = "0.1.0"
+source = "git+ssh://git@github.com/qorix-group/abi_tools_internal.git?rev=1196d20246a38718e469b42953714e5eddb15d56#1196d20246a38718e469b42953714e5eddb15d56"
+dependencies = [
+ "abi-types-parser",
+ "anyhow",
+ "log",
+]
+
+[[package]]
+name = "abi-types-parser"
+version = "0.1.0"
+source = "git+ssh://git@github.com/qorix-group/abi_tools_internal.git?rev=1196d20246a38718e469b42953714e5eddb15d56#1196d20246a38718e469b42953714e5eddb15d56"
+dependencies = [
+ "anyhow",
+ "ariadne",
+ "compact_str",
+ "log",
+ "logos",
+ "rustc-hash 2.1.1",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10,6 +33,28 @@ checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "anyhow"
+version = "1.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
+name = "ariadne"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f5e3dca4e09a6f340a61a0e9c7b61e030c69fc27bf29d73218f7e5e3b7638f"
+dependencies = [
+ "unicode-width",
+ "yansi",
+]
+
+[[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
 name = "bindgen"
@@ -28,7 +73,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "shlex",
  "syn",
  "which",
@@ -45,6 +90,15 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cc"
@@ -104,6 +158,14 @@ dependencies = [
 name = "com-api"
 version = "0.1.0"
 dependencies = [
+ "com-api-concept",
+ "com-api-runtime-iceoryx",
+]
+
+[[package]]
+name = "com-api-concept"
+version = "0.1.0"
+dependencies = [
  "iceoryx2",
 ]
 
@@ -111,6 +173,7 @@ dependencies = [
 name = "com-api-gen-iceoryx"
 version = "0.1.0"
 dependencies = [
+ "abi-types-codegen",
  "com-api",
  "com-api-runtime-iceoryx",
  "iceoryx2",
@@ -120,8 +183,22 @@ dependencies = [
 name = "com-api-runtime-iceoryx"
 version = "0.1.0"
 dependencies = [
- "com-api",
+ "com-api-concept",
  "iceoryx2",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
 ]
 
 [[package]]
@@ -177,6 +254,12 @@ dependencies = [
  "libc",
  "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "glob"
@@ -398,6 +481,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -436,6 +525,40 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "logos"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff472f899b4ec2d99161c51f60ff7075eeb3097069a36050d8037a6325eb8154"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "192a3a2b90b0c05b27a0b2c43eecdb7c415e29243acc3f89cc8247a5b693045c"
+dependencies = [
+ "beef",
+ "fnv",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "regex-syntax",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "605d9697bcd5ef3a42d38efc51541aa3d6a4a25f7ab6d1ed0da5ac632a26b470"
+dependencies = [
+ "logos-codegen",
+]
 
 [[package]]
 name = "memchr"
@@ -541,6 +664,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -552,6 +690,24 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -593,6 +749,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"
@@ -677,6 +839,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "which"
@@ -917,3 +1085,9 @@ checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"

--- a/com-api/examples/com-api-gen/com-api-gen-iceoryx/Cargo.toml
+++ b/com-api/examples/com-api-gen/com-api-gen-iceoryx/Cargo.toml
@@ -9,3 +9,6 @@ license = "Apache-2.0"
 iceoryx2 = { git = "https://github.com/eclipse-iceoryx/iceoryx2.git", version = "0.6.1" }
 com-api-runtime-iceoryx = { path = "../../../com-api-runtime-iceoryx" }
 com-api = { path = "../../../com-api", features = ["iceoryx"] }
+
+[build-dependencies]
+abi-types-codegen = { git = "ssh://git@github.com/qorix-group/abi_tools_internal.git", rev = "1196d20246a38718e469b42953714e5eddb15d56" }

--- a/com-api/examples/com-api-gen/com-api-gen-iceoryx/Cargo.toml
+++ b/com-api/examples/com-api-gen/com-api-gen-iceoryx/Cargo.toml
@@ -11,4 +11,4 @@ com-api-runtime-iceoryx = { path = "../../../com-api-runtime-iceoryx" }
 com-api = { path = "../../../com-api", features = ["iceoryx"] }
 
 [build-dependencies]
-abi-types-codegen = { git = "ssh://git@github.com/qorix-group/abi_tools_internal.git", rev = "1196d20246a38718e469b42953714e5eddb15d56" }
+abi-types-codegen = { git = "ssh://git@github.com/qorix-group/abi_tools_internal.git", rev = "1466ef338a666fa5b49a08cbabb48143c6a5efef" }

--- a/com-api/examples/com-api-gen/com-api-gen-iceoryx/build.rs
+++ b/com-api/examples/com-api-gen/com-api-gen-iceoryx/build.rs
@@ -1,0 +1,16 @@
+use std::path::Path;
+
+use abi_types_codegen::{
+    build,
+    config::{Config, RustOptions, Target},
+};
+
+fn main() {
+    let config = Config {
+        format: true,
+        source: Path::new("src/vehicle_interface.types").to_owned(),
+        target: Target::Rust,
+        rust: RustOptions { derive_reloc: true },
+    };
+    build(&config).unwrap();
+}

--- a/com-api/examples/com-api-gen/com-api-gen-iceoryx/build.rs
+++ b/com-api/examples/com-api-gen/com-api-gen-iceoryx/build.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::{fs, path::Path};
 
 use abi_types_codegen::{
     build,
@@ -6,9 +6,17 @@ use abi_types_codegen::{
 };
 
 fn main() {
+    let source = Path::new("src").join("vehicle_interface.types");
+    println!("cargo::rerun-if-changed={}", source.display());
+
+    let output_dir = Path::new("src").join("generated");
+    let output = output_dir.join("vehicle_interface.rs");
+    fs::create_dir_all(&output_dir).expect("create 'src/generated' directory");
+
     let config = Config {
         format: true,
-        source: Path::new("src/vehicle_interface.types").to_owned(),
+        source,
+        output: Some(output),
         target: Target::Rust,
         rust: RustOptions { derive_reloc: true },
     };

--- a/com-api/examples/com-api-gen/com-api-gen-iceoryx/src/generated/.gitignore
+++ b/com-api/examples/com-api-gen/com-api-gen-iceoryx/src/generated/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/com-api/examples/com-api-gen/com-api-gen-iceoryx/src/lib.rs
+++ b/com-api/examples/com-api-gen/com-api-gen-iceoryx/src/lib.rs
@@ -22,11 +22,15 @@
 //!
 //! ```
 
+mod vehicle_interface;
+
 use com_api::prelude::*;
 use com_api_runtime_iceoryx::{
     Publisher, RuntimeImpl, SampleConsumerBuilder, SampleProducerBuilder, SubscribableImpl,
 };
 use iceoryx2::prelude::*;
+
+use vehicle_interface::*;
 
 #[derive(Debug)]
 #[repr(C)]
@@ -39,33 +43,6 @@ unsafe impl ZeroCopySend for Tire {}
 pub struct Exhaust {}
 unsafe impl Reloc for Exhaust {}
 unsafe impl ZeroCopySend for Exhaust {}
-
-#[derive(Debug)]
-#[repr(C)]
-pub struct WindowsPosition {
-    pub fl: u8,
-    pub fr: u8,
-    pub rl: u8,
-    pub rr: u8,
-}
-unsafe impl Reloc for WindowsPosition {}
-unsafe impl ZeroCopySend for WindowsPosition {}
-
-#[derive(Debug)]
-#[repr(C)]
-pub struct RainSensor {
-    pub is_wet: bool,
-}
-unsafe impl Reloc for RainSensor {}
-unsafe impl ZeroCopySend for RainSensor {}
-
-#[derive(Debug)]
-#[repr(C)]
-pub struct CloseWindows {
-    pub close: bool,
-}
-unsafe impl Reloc for CloseWindows {}
-unsafe impl ZeroCopySend for CloseWindows {}
 
 #[derive(Debug)]
 #[repr(C)]

--- a/com-api/examples/com-api-gen/com-api-gen-iceoryx/src/lib.rs
+++ b/com-api/examples/com-api-gen/com-api-gen-iceoryx/src/lib.rs
@@ -22,6 +22,7 @@
 //!
 //! ```
 
+#[path = "generated/vehicle_interface.rs"]
 mod vehicle_interface;
 
 use com_api::prelude::*;

--- a/com-api/examples/com-api-gen/com-api-gen-iceoryx/src/vehicle_interface.types
+++ b/com-api/examples/com-api-gen/com-api-gen-iceoryx/src/vehicle_interface.types
@@ -1,0 +1,14 @@
+struct WindowsPosition {
+    fl: u8,
+    fr: u8,
+    rl: u8,
+    rr: u8,
+}
+
+struct RainSensor {
+    is_wet: bool,
+}
+
+struct CloseWindows {
+    close: bool,
+}


### PR DESCRIPTION
The code generation is triggered by `build.rs`, and the result is placed into the `src/generated` directory, so that it can be easily included:

```rust
#[path = "generated/vehicle_interface.rs"]
mod vehicle_interface;
```

This way, rust-analyzer can see the generated code as well.